### PR TITLE
removed unneeded args on show_ui, added the latest rb3compat from covera...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+*.py[co]
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+
+#Translations
+*.mo
+
+#Mr Developer
+.mr.developer.cfg
+
+img/usericons/popups.xml

--- a/Equalizer.py
+++ b/Equalizer.py
@@ -227,7 +227,7 @@ class EQControl(Gtk.Dialog):
         print "closing ui"
         self.set_visible(False)
         return True
-    def show_ui(self, shell, state):
+    def show_ui(self, *args):
         print "showing UI"
         self.show_all()
         self.present()

--- a/ParametricEQ_rb3compat.py
+++ b/ParametricEQ_rb3compat.py
@@ -25,10 +25,43 @@
 from gi.repository import Gtk
 from gi.repository import Gio
 from gi.repository import GLib
+from gi.repository import GObject
+from gi.repository import RB
 import sys
 import rb
 import lxml.etree as ET
 
+def pygobject_version():
+    ''' 
+    returns float of the major and minor parts of a pygobject version 
+    e.g. version (3, 9, 5) return float(3.9)
+    '''
+    to_number = lambda t: ".".join(str(v) for v in t)
+    
+    str_version = to_number(GObject.pygobject_version)
+    
+    return float(str_version.rsplit('.',1)[0])
+    
+def compare_pygobject_version(version):
+    '''
+    return True if version is less than pygobject_version
+    i.e. 3.9 < 3.11
+    '''
+    to_number = lambda t: ".".join(str(v) for v in t)
+    
+    str_version = to_number(GObject.pygobject_version)
+  
+    split = str_version.rsplit('.',2)
+    split_compare = version.rsplit('.',2)
+    
+    if int(split_compare[0])<int(split[0]):
+        return True
+        
+    if int(split_compare[1])<int(split[1]):
+        return True
+        
+    return False
+        
 PYVER = sys.version_info[0]
 
 if PYVER >= 3:
@@ -114,12 +147,11 @@ def quote_plus(uri):
     else:
         return urllib.quote_plus(uri)
 
-        
-def is_rb3(shell):
-    if hasattr( shell.props.window, 'add_action' ):
-        return True
+def is_rb3(*args):
+    if hasattr(RB.Shell.props, 'ui_manager'):
+        return False
     else:
-        return False    
+        return True 
         
 class Menu(object):
     '''
@@ -134,6 +166,7 @@ class Menu(object):
         self._unique_num = 0
         
         self._rbmenu_items = {}
+        self._rbmenu_objects = {}
         
     def add_menu_item(self, menubar, section_name, action):
         '''
@@ -227,8 +260,6 @@ class Menu(object):
             for menu_item in self._rbmenu_items:
                 bar.remove(self._rbmenu_items[menu_item])
 
-            #del self._rbmenu_items[:]
-            
             bar.show_all()
             uim.ensure_update()
         
@@ -269,7 +300,7 @@ class Menu(object):
         
     def _connect_rb2_signals(self, signals):
         def _menu_connect(menu_item_name, func):
-            menu_item = self.builder.get_object(menu_item_name)
+            menu_item = self.get_menu_object(menu_item_name)
             menu_item.connect('activate', func)
             
         for key,value in signals.items():
@@ -291,6 +322,8 @@ class Menu(object):
         utility function to obtain the GtkMenu from the menu UI file
         :param popup_name: `str` is the name menu-id in the UI file
         '''
+        if popup_name in self._rbmenu_objects:
+            return self._rbmenu_objects[popup_name]
         item = self.builder.get_object(popup_name)
         
         if is_rb3(self.shell):
@@ -301,6 +334,8 @@ class Menu(object):
         else:
             popup_menu = item
         
+        self._rbmenu_objects[popup_name] = popup_menu
+        
         return popup_menu
             
     def get_menu_object(self, menu_name_or_link):
@@ -308,8 +343,9 @@ class Menu(object):
         utility function returns the GtkMenuItem/Gio.MenuItem
         :param menu_name_or_link: `str` to search for in the UI file
         '''
+        if menu_name_or_link in self._rbmenu_objects:
+            return self._rbmenu_objects[menu_name_or_link]
         item = self.builder.get_object(menu_name_or_link)
-
         if is_rb3(self.shell):
             if item:
                 popup_menu = item
@@ -318,7 +354,9 @@ class Menu(object):
                 popup_menu = app.get_plugin_menu(menu_name_or_link)
         else:
             popup_menu = item
-            
+        print (menu_name_or_link)
+        self._rbmenu_objects[menu_name_or_link] = popup_menu
+        
         return popup_menu
 
     def set_sensitive(self, menu_or_action_item, enable):
@@ -333,7 +371,7 @@ class Menu(object):
             item = self.shell.props.window.lookup_action(menu_or_action_item)
             item.set_enabled(enable)
         else:
-            item = self.builder.get_object(menu_or_action_item)
+            item = self.get_menu_object(menu_or_action_item)
             item.set_sensitive(enable)
             
 class ActionGroup(object):
@@ -448,14 +486,19 @@ class ActionGroup(object):
             if accel:
                 app.add_accelerator(accel, action_type+"."+action_name, None)
         else:
+            if 'stock_id' in args:
+                stock_id = args['stock_id']
+            else:
+                stock_id = Gtk.STOCK_CLEAR
+                
             if state == ActionGroup.TOGGLE:
                 action = Gtk.ToggleAction(label=label,
                     name=action_name,
-                   tooltip='', stock_id=Gtk.STOCK_CLEAR)
+                   tooltip='', stock_id=stock_id)
             else:
                 action = Gtk.Action(label=label,
                     name=action_name,
-                   tooltip='', stock_id=Gtk.STOCK_CLEAR)
+                   tooltip='', stock_id=stock_id)
                    
             if accel:
                 self.actiongroup.add_action_with_accel(action, accel)
@@ -692,6 +735,7 @@ class Action(object):
     def _activate(self, action, *args):
         if self._do_update_state:
             self._current_state = not self._current_state
+            self.set_state(self._current_state)
         
         self._connect_func(action, None, self._connect_args)
         
@@ -740,6 +784,14 @@ class Action(object):
         else:
             return self.action.get_sensitive()
             
+    def set_state(self, value):
+        ''' 
+        set the state of a stateful action - this is applicable only
+        to RB2.99+
+        '''
+        if is_rb3(self.shell) and self.action.props.state_type:
+            self.action.change_state(GLib.Variant('b', value))
+
     def activate(self):
         ''' 
         invokes the activate signal for the action


### PR DESCRIPTION
...rt-browser and added .gitignore so that compiled files are not committed to git

ok - I didnt get a segmentation fault - just an error about show_ui not having enough arguments.  This was resolved by just using *args - you didnt appear to be using any arguments in that function anyway, but you need a variable number of args since the callback function works different between rb2.96 and rb2.99.

Anyway - the plugin and the equalizer dialog appears to display correctly in both versions of rhythmbox ok.

Note - I havent investigated why the sound didnt update with changing the value of any equalizer bands - I presume this is something you are working on?

you perhaps should also think about running 2to3-3.3 on every .py file EXCEPT the rb3compat module  - then your plugin will be almost ready for Rhythmbox 3 as well - N.B. you need to change the Loader=python to Loader=python3 in the .plugin file to make the plugin run in RB3.
